### PR TITLE
Add other custom rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,10 +55,10 @@ resource "cloudflare_ruleset" "zone_level_geo_blocking" {
   phase   = "http_request_firewall_custom"
 
   dynamic "rules" {
-    for_each = toset(var.country_block_list)
+    for_each = var.country_block_list
     content {
       description = "Block traffic from ${rules.value} - Defined via Terraform"
-      expression  = "(ip.src.country eq \"${rules.value}\")"
+      expression  = "(ip.src.country eq \"${rules.key}\")"
       action      = "block"
       enabled     = true
     }

--- a/main.tf
+++ b/main.tf
@@ -44,3 +44,23 @@ resource "cloudflare_ruleset" "zone_level_waf_custom_rules" {
     }
   }
 }
+
+# For Geoblocking based on Country Codes
+resource "cloudflare_ruleset" "zone_level_geo_blocking" {
+  count = length(var.country_block_list) != 0 ? length(var.domains) : 0 # No need to create if country block list is empty
+
+  zone_id = lookup(data.cloudflare_zones.zones[count.index].zones[0], "id")
+  name    = "Geo Block by Country Code"
+  kind    = "zone"
+  phase   = "http_request_firewall_custom"
+
+  dynamic "rules" {
+    for_each = toset(var.country_block_list)
+    content {
+      description = "Block traffic from ${rules.value} - Defined via Terraform"
+      expression  = "(ip.src.country eq \"${rules.value}\")"
+      action      = "block"
+      enabled     = true
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -15,3 +15,43 @@ variable "firewall_rules" {
     phases      = optional(list(string))
   }))
 }
+
+variable "country_block_list" {
+  type        = list(string)
+  description = "A list to contain country codes of traffic that will be blocked"
+  default = [
+    "DZ", # Algeria
+    "AF", # Afghanistan
+    "BD", # Bangladesh
+    "BY", # Belarus
+    "CF", # Central African Republic
+    "CD", # The Democratic Republic of Congo
+    "CU", # Cuba
+    "ET", # Ethiopia
+    "ER", # Eritrea
+    "PS", # Palestinian Territory (Gaza Strip / West Bank)
+    "IR", # Iran
+    "IQ", # Iraq
+    "XK", # Kosovo
+    "LB", # Lebanon
+    "LY", # Libya
+    "ML", # Mali
+    "MA", # Morocco
+    "MM", # Myanmar (Burma)
+    "NI", # Nicaragua
+    "NE", # Niger
+    "KP", # North Korea
+    "PK", # Pakistan
+    "QA", # Qatar
+    "RU", # Russia
+    "SI", # Slovenia
+    "SO", # Somalia
+    "SS", # South Sudan
+    "SD", # Sudan
+    "SY", # Syrian Arab Republic
+    "UA", # Ukraine
+    "YE", # Yemen
+    "ZW", # Zimbabwe
+  ]
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -17,41 +17,8 @@ variable "firewall_rules" {
 }
 
 variable "country_block_list" {
-  type        = list(string)
+  type        = map(string)
   description = "A list to contain country codes of traffic that will be blocked"
-  default = [
-    "DZ", # Algeria
-    "AF", # Afghanistan
-    "BD", # Bangladesh
-    "BY", # Belarus
-    "CF", # Central African Republic
-    "CD", # The Democratic Republic of Congo
-    "CU", # Cuba
-    "ET", # Ethiopia
-    "ER", # Eritrea
-    "PS", # Palestinian Territory (Gaza Strip / West Bank)
-    "IR", # Iran
-    "IQ", # Iraq
-    "XK", # Kosovo
-    "LB", # Lebanon
-    "LY", # Libya
-    "ML", # Mali
-    "MA", # Morocco
-    "MM", # Myanmar (Burma)
-    "NI", # Nicaragua
-    "NE", # Niger
-    "KP", # North Korea
-    "PK", # Pakistan
-    "QA", # Qatar
-    "RU", # Russia
-    "SI", # Slovenia
-    "SO", # Somalia
-    "SS", # South Sudan
-    "SD", # Sudan
-    "SY", # Syrian Arab Republic
-    "UA", # Ukraine
-    "YE", # Yemen
-    "ZW", # Zimbabwe
-  ]
+  default     = {}
 }
 


### PR DESCRIPTION
Adds default configuration to GeoBlock countries that we've been told we need to geoblock. This change makes the list default to the countries we've been told we need to block. I'm open to a discussion around whether or not we should make this a default. But I like the idea that we can create releases with up to date info and simply by updating the module products can get an updated list.